### PR TITLE
feat: blocks versioning

### DIFF
--- a/app/routes/edge-cms/blocks/blocks.$id.instances.$action.tsx
+++ b/app/routes/edge-cms/blocks/blocks.$id.instances.$action.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-router';
 import { useState } from 'react';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import {
 	getBlockCollectionById,
 	getBlockSchemaProperties,
@@ -116,7 +117,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const { id, action } = params;
 	const blockId = parseInt(id);

--- a/app/routes/edge-cms/blocks/blocks.$id.tsx
+++ b/app/routes/edge-cms/blocks/blocks.$id.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-router';
 import { useState, useRef } from 'react';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import {
 	getBlockCollectionById,
 	getBlockInstances,
@@ -77,7 +78,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const blockId = parseInt(params.id);
 	const formData = await request.formData();

--- a/app/routes/edge-cms/blocks/blocks.new.tsx
+++ b/app/routes/edge-cms/blocks/blocks.new.tsx
@@ -8,6 +8,7 @@ import {
 import { useState } from 'react';
 import { kebabCase, startCase } from 'lodash-es';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import {
 	getBlockSchemas,
 	getSections,
@@ -45,7 +46,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const formData = await request.formData();
 	const name = formData.get('name') as string;

--- a/app/routes/edge-cms/blocks/blocks.schemas.$id.properties.new.tsx
+++ b/app/routes/edge-cms/blocks/blocks.schemas.$id.properties.new.tsx
@@ -2,6 +2,7 @@ import { useLoaderData, useFetcher, Link, redirect } from 'react-router';
 import { useState } from 'react';
 import { camelCase } from 'lodash-es';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import {
 	getBlockSchemas,
 	createBlockSchemaProperty,
@@ -36,7 +37,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request, params }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const schemaId = parseInt(params.id);
 	const formData = await request.formData();

--- a/app/routes/edge-cms/blocks/blocks.schemas.$id.tsx
+++ b/app/routes/edge-cms/blocks/blocks.schemas.$id.tsx
@@ -7,6 +7,7 @@ import {
 	useOutlet,
 } from 'react-router';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import {
 	getBlockSchemas,
 	getBlockSchemaById,
@@ -43,7 +44,8 @@ export async function loader({ request, params }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const formData = await request.formData();
 	const intent = formData.get('intent');

--- a/app/routes/edge-cms/blocks/blocks.schemas.new.tsx
+++ b/app/routes/edge-cms/blocks/blocks.schemas.new.tsx
@@ -1,6 +1,7 @@
 import { useFetcher, Link, redirect } from 'react-router';
 import { kebabCase, startCase } from 'lodash-es';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import { createBlockSchema } from '~/utils/db.server';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
@@ -15,7 +16,8 @@ import { env } from 'cloudflare:workers';
 import type { Route } from './+types/blocks.schemas.new';
 
 export async function action({ request }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const formData = await request.formData();
 	const name = formData.get('name') as string;

--- a/app/routes/edge-cms/blocks/blocks.schemas.tsx
+++ b/app/routes/edge-cms/blocks/blocks.schemas.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router';
 import { useState } from 'react';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import {
 	getBlockSchemas,
 	getBlockSchemaProperties,
@@ -43,7 +44,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const formData = await request.formData();
 	const intent = formData.get('intent');

--- a/app/routes/edge-cms/blocks/blocks.tsx
+++ b/app/routes/edge-cms/blocks/blocks.tsx
@@ -1,5 +1,6 @@
 import { useLoaderData, useFetcher, Link, Outlet } from 'react-router';
 import { requireAuth } from '~/utils/auth.middleware';
+import { ensureDraftVersion } from '~/utils/ensure-draft-version.server';
 import {
 	getBlockSchemas,
 	getBlockSchemaProperties,
@@ -86,7 +87,8 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
-	await requireAuth(request, env);
+	const auth = await requireAuth(request, env);
+	await ensureDraftVersion(auth.user.id);
 
 	const formData = await request.formData();
 	const intent = formData.get('intent');

--- a/app/routes/edge-cms/public/blocks.$collection.tsx
+++ b/app/routes/edge-cms/public/blocks.$collection.tsx
@@ -1,7 +1,38 @@
-import { getBlockCollectionData } from '~/utils/db.server';
+import { getBlockCollectionData, getLatestVersion } from '~/utils/db.server';
+import { env } from 'cloudflare:workers';
 
 export async function loader({ params }: { params: { collection: string } }) {
-	const data = await getBlockCollectionData(params.collection);
+	const collectionName = params.collection;
+
+	// Get live version to determine which snapshot to serve
+	const liveVersion = await getLatestVersion('live');
+
+	if (liveVersion) {
+		// Try R2 snapshot
+		const file = await env.BACKUPS_BUCKET.get(
+			`${liveVersion.id}/blocks/${collectionName}.json`,
+		);
+
+		if (file) {
+			const data = await file.text();
+			return new Response(data, {
+				headers: {
+					'Content-Type': 'application/json',
+					'Cache-Control':
+						'public, max-age=604800, stale-while-revalidate=259200',
+				},
+			});
+		}
+
+		// Collection was added after publish — don't leak draft content
+		return new Response(JSON.stringify({ error: 'Collection not found' }), {
+			status: 404,
+			headers: { 'Content-Type': 'application/json' },
+		});
+	}
+
+	// No published version yet — serve from D1 (initial setup / legacy)
+	const data = await getBlockCollectionData(collectionName);
 
 	if (!data) {
 		return new Response(JSON.stringify({ error: 'Collection not found' }), {

--- a/app/utils/ensure-draft-version.server.ts
+++ b/app/utils/ensure-draft-version.server.ts
@@ -1,0 +1,15 @@
+import { getLatestVersion, createVersion } from './db/versions.server';
+
+export async function ensureDraftVersion(userId?: string): Promise<void> {
+	const [draftVersion, liveVersion] = await Promise.all([
+		getLatestVersion('draft'),
+		getLatestVersion('live'),
+	]);
+
+	if (draftVersion == null) {
+		const description = liveVersion
+			? `fork from v${liveVersion.id}`
+			: new Date().toISOString().split('T')[0];
+		await createVersion(description, userId);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the source of truth for public blocks responses to versioned R2 snapshots and adds destructive restore logic that deletes and reinserts all block tables during rollback; mistakes could cause content loss or incorrect content being served.
> 
> **Overview**
> Adds **blocks versioning** to match the existing translations version workflow: all Edge CMS blocks/schema mutation `action`s now call `ensureDraftVersion(auth.user.id)` to guarantee a draft exists before writing.
> 
> On publish (`ReleaseVersionWorkflow`), the workflow now snapshots each block collection’s API payload to R2 under `/<version>/blocks/<collection>.json` and stores a gzipped full blocks-table backup (`blocks-backup.gz`) for rollback.
> 
> Public blocks API (`public/blocks.$collection`) now serves **only live** content by reading the latest live snapshot from R2 and returning `404` if the collection wasn’t part of the published version (falling back to D1 only when no live version exists). Rollback workflow now optionally restores all block tables from `blocks-backup.gz` via new DB helpers (`getBlocksBackupData`, `restoreBlocksFromBackup`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f9f36f70955c9747d7b14058454b2f3e8f433e57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->