### PR TITLE
feat: service bindings

### DIFF
--- a/workers/app.ts
+++ b/workers/app.ts
@@ -58,4 +58,5 @@ export default {
 	},
 } satisfies ExportedHandler<Env>;
 
+export { EdgeCMSService } from './edgecms-service';
 export { ReleaseVersionWorkflow, RollbackVersionWorkflow, AITranslateWorkflow };

--- a/workers/edgecms-service.ts
+++ b/workers/edgecms-service.ts
@@ -1,0 +1,140 @@
+import { WorkerEntrypoint } from 'cloudflare:workers';
+import { env } from 'cloudflare:workers';
+import {
+	getLanguages,
+	getTranslations,
+	getLatestVersion,
+	getBlockCollectionData,
+	getMediaByFilename,
+} from '~/utils/db.server';
+import { buildVersionedFilename } from '~/utils/media.server';
+
+export class EdgeCMSService extends WorkerEntrypoint<Env> {
+	/**
+	 * Returns translations for a locale from the live R2 snapshot.
+	 * Falls back to 404 if no live version or snapshot exists.
+	 */
+	async getTranslations(locale: string): Promise<Record<string, string>> {
+		const liveVersion = await getLatestVersion('live');
+		if (!liveVersion) {
+			throw new Error('No live version found');
+		}
+
+		const file = await env.BACKUPS_BUCKET.get(
+			`${liveVersion.id}/${locale}.json`,
+		);
+		if (!file) {
+			throw new Error(`No translation file found for locale: ${locale}`);
+		}
+
+		return file.json();
+	}
+
+	/**
+	 * Returns block collection data from the live R2 snapshot,
+	 * falling back to DB if no live version exists.
+	 */
+	async getBlocks(collection: string) {
+		const liveVersion = await getLatestVersion('live');
+
+		if (liveVersion) {
+			const file = await env.BACKUPS_BUCKET.get(
+				`${liveVersion.id}/blocks/${collection}.json`,
+			);
+			if (file) {
+				return file.json();
+			}
+			// Collection was added after publish — don't leak draft content
+			throw new Error(`Collection not found: ${collection}`);
+		}
+
+		// No published version yet — serve from D1
+		const data = await getBlockCollectionData(collection);
+		if (!data) {
+			throw new Error(`Collection not found: ${collection}`);
+		}
+		return data;
+	}
+
+	/**
+	 * Returns media file metadata and a ReadableStream body from R2.
+	 */
+	async getMedia(
+		filename: string,
+		version?: number,
+	): Promise<{
+		contentType: string;
+		size: number;
+		etag: string;
+		body: ReadableStream;
+	}> {
+		const media = await getMediaByFilename(filename, version);
+		if (!media) {
+			throw new Error(`Media not found: ${filename}`);
+		}
+
+		const versionedFilename = buildVersionedFilename(
+			media.filename,
+			media.version,
+		);
+		const object = await env.MEDIA_BUCKET.get(versionedFilename);
+		if (!object) {
+			throw new Error(`Media file not found in storage: ${filename}`);
+		}
+
+		return {
+			contentType: media.mimeType,
+			size: media.sizeBytes,
+			etag: object.httpEtag,
+			body: object.body,
+		};
+	}
+
+	/**
+	 * Returns available languages and the default locale.
+	 */
+	async getLanguages(): Promise<{
+		languages: { locale: string; default: boolean }[];
+		defaultLocale: string | null;
+	}> {
+		const languages = await getLanguages();
+		const defaultLocale =
+			languages.find(l => l.default)?.locale || null;
+		return { languages, defaultLocale };
+	}
+
+	/**
+	 * Pulls all translations grouped by locale (draft state from DB).
+	 */
+	async pullTranslations(): Promise<{
+		languages: { locale: string; default: boolean }[];
+		defaultLocale: string | null;
+		translations: Record<string, Record<string, string>>;
+	}> {
+		const [languages, allTranslations] = await Promise.all([
+			getLanguages(),
+			getTranslations({}),
+		]);
+
+		const defaultLocale =
+			languages.find(l => l.default)?.locale || null;
+
+		const translationsByLocale: Record<string, Record<string, string>> = {};
+		for (const lang of languages) {
+			translationsByLocale[lang.locale] = {};
+		}
+		for (const translation of allTranslations) {
+			if (!translationsByLocale[translation.language]) {
+				translationsByLocale[translation.language] = {};
+			}
+			translationsByLocale[translation.language][translation.key] =
+				translation.value;
+		}
+
+		return {
+			languages,
+			defaultLocale,
+			translations: translationsByLocale,
+		};
+	}
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -47,6 +47,14 @@
 	/**
 	 * Service Bindings (communicate between multiple Workers)
 	 * https://developers.cloudflare.com/workers/wrangler/configuration/#service-bindings
+	 *
+	 * Consumer config example (in the consuming worker's wrangler.toml):
+	 *   [[services]]
+	 *   binding = "EDGECMS"
+	 *   service = "edgecms"
+	 *   entrypoint = "EdgeCMSService"
+	 *
+	 * Then call: const translations = await env.EDGECMS.getTranslations("en")
 	 */
 	// "services": [{ "binding": "MY_SERVICE", "service": "my-service" }]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new cross-worker API surface that reads from D1/R2 and affects what content can be served (live snapshot vs DB fallback); incorrect binding/config or error handling could cause runtime failures or unintended content exposure.
> 
> **Overview**
> Adds a new `EdgeCMSService` Worker entrypoint intended for Cloudflare *service bindings*, exposing methods to fetch live translations and blocks from the published R2 snapshot (with a DB fallback only when no live version exists), stream media from R2 with metadata, and pull draft translations grouped by locale from the DB.
> 
> Exports `EdgeCMSService` from `workers/app.ts` and documents how to configure a consuming worker’s `[[services]]` binding/`entrypoint` in `wrangler.jsonc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2056fe6683442af1c63e017c12d471926c9b377a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->